### PR TITLE
feat: lazy render section backgrounds

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,4 +1,5 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
+import { useRef } from 'react'
 import { FaCode, FaCoffee, FaHeart, FaLightbulb } from 'react-icons/fa'
 import AnimatedBackground from './ui/animated-background'
 
@@ -26,9 +27,12 @@ const About = () => {
     }
   ]
 
+  const ref = useRef(null)
+  const isInView = useInView(ref, { amount: 0.2 })
+
   return (
-    <section id="about" className="relative bg-gradient-to-r from-[#171010] to-[#362222] text-white py-16 overflow-hidden">
-      <AnimatedBackground variant="about" />
+    <section ref={ref} id="about" className="relative bg-gradient-to-r from-[#171010] to-[#362222] text-white py-16 overflow-hidden">
+      {isInView && <AnimatedBackground variant="about" />}
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <motion.div
           initial={{ opacity: 0, y: 50 }}

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,6 +1,6 @@
-import { color, motion } from 'framer-motion'
+import { color, motion, useInView } from 'framer-motion'
 import { FaEnvelope, FaPhone, FaMapMarkerAlt, FaPaperPlane, FaGithub, FaLinkedin, FaExternalLinkAlt } from 'react-icons/fa'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import toast from 'react-hot-toast'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -15,6 +15,9 @@ const Contact = () => {
     message: ''
   })
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const ref = useRef(null)
+  const isInView = useInView(ref, { amount: 0.2 })
 
   const handleChange = (e) => {
     setFormData({
@@ -102,8 +105,8 @@ const Contact = () => {
   ]
 
   return (
-    <section id="contact" className="relative bg-gradient-to-r from-[#171010] to-[#423F3E] text-white py-16 overflow-hidden">
-      <AnimatedBackground variant="contact" />
+    <section ref={ref} id="contact" className="relative bg-gradient-to-r from-[#171010] to-[#423F3E] text-white py-16 overflow-hidden">
+      {isInView && <AnimatedBackground variant="contact" />}
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <motion.div
           initial={{ opacity: 0, y: 50 }}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { motion } from 'framer-motion'
+import React, { useRef } from 'react'
+import { motion, useInView } from 'framer-motion'
 import { FaHeart, FaGithub, FaLinkedin, FaExternalLinkAlt, FaEnvelope, FaArrowUp } from 'react-icons/fa'
 import { Button } from '@/components/ui/button'
 import AnimatedBackground from './ui/animated-background'
@@ -39,9 +39,12 @@ const Footer = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
+  const ref = useRef(null)
+  const isInView = useInView(ref, { amount: 0.2 })
+
   return (
-    <footer className="relative bg-gradient-to-r from-[#2B2B2B] to-[#171010] text-white pt-8 pb-4 overflow-hidden">
-      <AnimatedBackground variant="footer" />
+    <footer ref={ref} className="relative bg-gradient-to-r from-[#2B2B2B] to-[#171010] text-white pt-8 pb-4 overflow-hidden">
+      {isInView && <AnimatedBackground variant="footer" />}
 
       <div className="relative z-10">
         {/* Main Footer Content */}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,12 +1,16 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
 import { FaDownload, FaExternalLinkAlt } from 'react-icons/fa'
 import { Button } from '@/components/ui/button'
 import AnimatedBackground from './ui/animated-background'
+import { useRef } from 'react'
 
 const Hero = () => {
+  const ref = useRef(null)
+  const isInView = useInView(ref, { amount: 0.2 })
+
   return (
-    <section className="relative min-h-screen bg-gradient-to-br from-[#171010] via-[#2B2B2B] to-[#423F3E] text-white flex items-center justify-center overflow-hidden">
-      <AnimatedBackground variant="hero" />
+    <section ref={ref} className="relative min-h-screen bg-gradient-to-br from-[#171010] via-[#2B2B2B] to-[#423F3E] text-white flex items-center justify-center overflow-hidden">
+      {isInView && <AnimatedBackground variant="hero" />}
       <div className="absolute inset-0">
         <div className="absolute inset-0 bg-gradient-to-br from-[#362222]/5 via-[#423F3E]/10 to-[#171010]/20"></div>
       </div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,4 +1,5 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
+import { useRef } from 'react'
 import { FaExternalLinkAlt, FaGithub, FaCode, FaDatabase, FaGlobe } from 'react-icons/fa'
 import { Button } from '@/components/ui/button'
 import AnimatedBackground from './ui/animated-background'
@@ -55,9 +56,12 @@ const Projects = () => {
     }
   ]
 
+  const ref = useRef(null)
+  const isInView = useInView(ref, { amount: 0.2 })
+
   return (
-    <section id="projects" className="relative bg-gradient-to-r from-[#362222] to-[#423F3E] text-white py-16 overflow-hidden">
-      <AnimatedBackground variant="projects" />
+    <section ref={ref} id="projects" className="relative bg-gradient-to-r from-[#362222] to-[#423F3E] text-white py-16 overflow-hidden">
+      {isInView && <AnimatedBackground variant="projects" />}
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <motion.div
           initial={{ opacity: 0, y: 50 }}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,4 +1,5 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
+import { useRef } from 'react'
 import AnimatedBackground from './ui/animated-background'
 import { 
   FaCode, 
@@ -54,9 +55,12 @@ const Skills = () => {
     </motion.span>
   )
 
+  const ref = useRef(null)
+  const isInView = useInView(ref, { amount: 0.2 })
+
   return (
-    <section id="skills" className="relative bg-gradient-to-r from-[#423F3E] to-[#171010] text-white py-16 overflow-hidden">
-      <AnimatedBackground variant="skills" />
+    <section ref={ref} id="skills" className="relative bg-gradient-to-r from-[#423F3E] to-[#171010] text-white py-16 overflow-hidden">
+      {isInView && <AnimatedBackground variant="skills" />}
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 relative z-10">
         <motion.div
           initial={{ opacity: 0, y: 50 }}


### PR DESCRIPTION
## Summary
- render AnimatedBackground only when section enters viewport using useInView
- refactor Hero, About, Skills, Projects, Contact, and Footer sections for viewport-aware backgrounds

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 'motion' defined but never used in multiple files)


------
https://chatgpt.com/codex/tasks/task_e_6899524b16848330802f51d842b7b6e5