### PR TITLE
Reduce DOM elements in AnimatedBackground

### DIFF
--- a/src/components/ui/animated-background.jsx
+++ b/src/components/ui/animated-background.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { motion } from 'framer-motion'
+import React, { useEffect, useRef } from 'react'
+import { motion } from 'framer-motion' // eslint-disable-line no-unused-vars
 
 const AnimatedBackground = ({ variant = 'default' }) => {
   const getVariantConfig = () => {
@@ -7,8 +7,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       case 'hero':
         return {
           primaryColor: 'bg-[#423F3E]/30',
-          secondaryColor: 'bg-[#362222]/20',
-          particleColor: 'bg-[#423F3E]',
+          particleColor: '#423F3E',
           starColor: 'bg-[#423F3E]',
           particleCount: 50,
           starCount: 30
@@ -16,8 +15,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       case 'about':
         return {
           primaryColor: 'bg-[#2B2B2B]/40',
-          secondaryColor: 'bg-[#423F3E]/30',
-          particleColor: 'bg-[#362222]',
+          particleColor: '#362222',
           starColor: 'bg-[#423F3E]',
           particleCount: 40,
           starCount: 25
@@ -25,8 +23,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       case 'skills':
         return {
           primaryColor: 'bg-[#423F3E]/35',
-          secondaryColor: 'bg-[#171010]/50',
-          particleColor: 'bg-[#362222]',
+          particleColor: '#362222',
           starColor: 'bg-[#423F3E]',
           particleCount: 45,
           starCount: 35
@@ -34,8 +31,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       case 'projects':
         return {
           primaryColor: 'bg-[#171010]/60',
-          secondaryColor: 'bg-[#423F3E]/40',
-          particleColor: 'bg-[#362222]',
+          particleColor: '#362222',
           starColor: 'bg-[#423F3E]',
           particleCount: 40,
           starCount: 30
@@ -43,8 +39,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       case 'contact':
         return {
           primaryColor: 'bg-[#2B2B2B]/50',
-          secondaryColor: 'bg-[#362222]/15',
-          particleColor: 'bg-[#423F3E]',
+          particleColor: '#423F3E',
           starColor: 'bg-[#362222]',
           particleCount: 35,
           starCount: 25
@@ -52,8 +47,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       case 'footer':
         return {
           primaryColor: 'bg-[#171010]/70',
-          secondaryColor: 'bg-[#2B2B2B]/40',
-          particleColor: 'bg-[#362222]',
+          particleColor: '#362222',
           starColor: 'bg-[#423F3E]',
           particleCount: 30,
           starCount: 20
@@ -61,8 +55,7 @@ const AnimatedBackground = ({ variant = 'default' }) => {
       default:
         return {
           primaryColor: 'bg-[#2B2B2B]/30',
-          secondaryColor: 'bg-[#171010]/40',
-          particleColor: 'bg-[#362222]',
+          particleColor: '#362222',
           starColor: 'bg-[#423F3E]',
           particleCount: 30,
           starCount: 20
@@ -71,62 +64,71 @@ const AnimatedBackground = ({ variant = 'default' }) => {
   }
 
   const config = getVariantConfig()
-  
+  const canvasRef = useRef(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    let frame
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth
+      canvas.height = canvas.offsetHeight
+    }
+    resize()
+    window.addEventListener('resize', resize)
+
+    const particles = [...Array(config.particleCount)].map(() => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      radius: Math.random() * 2 + 1,
+      speed: Math.random() * 0.5 + 0.2,
+      drift: Math.random() * 0.5 - 0.25
+    }))
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.fillStyle = config.particleColor
+      particles.forEach((p) => {
+        p.y -= p.speed
+        p.x += p.drift
+        if (p.y < 0) p.y = canvas.height
+        if (p.x < 0) p.x = canvas.width
+        if (p.x > canvas.width) p.x = 0
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2)
+        ctx.fill()
+      })
+      frame = requestAnimationFrame(draw)
+    }
+    draw()
+
+    return () => {
+      cancelAnimationFrame(frame)
+      window.removeEventListener('resize', resize)
+    }
+  }, [config])
+
   return (
     <div className="absolute inset-0 overflow-hidden">
-      {/* Animated gradient orbs */}
+      {/* Animated gradient orb */}
       <motion.div
-        className={`absolute w-96 h-96 ${config.primaryColor} rounded-full blur-3xl`}
+        className={`absolute w-80 h-80 ${config.primaryColor} rounded-full blur-2xl`}
         animate={{
           x: [0, 100, 0],
           y: [0, -50, 0],
-          scale: [1, 1.2, 1],
+          scale: [1, 1.2, 1]
         }}
         transition={{
           duration: 20,
           repeat: Infinity,
-          ease: "easeInOut"
+          ease: 'easeInOut'
         }}
-        style={{ top: '10%', left: '10%' }}
-      />
-      
-      <motion.div
-        className={`absolute w-96 h-96 ${config.secondaryColor} rounded-full blur-3xl`}
-        animate={{
-          x: [0, -100, 0],
-          y: [0, 100, 0],
-          scale: [1.2, 1, 1.2],
-        }}
-        transition={{
-          duration: 25,
-          repeat: Infinity,
-          ease: "easeInOut"
-        }}
-        style={{ bottom: '10%', right: '10%' }}
+        style={{ top: '15%', left: '15%' }}
       />
 
-      {/* Floating particles */}
-      {[...Array(config.particleCount)].map((_, i) => (
-        <motion.div
-          key={`particle-${i}`}
-          className={`absolute w-1 h-1 ${config.particleColor} rounded-full opacity-20`}
-          animate={{
-            y: [0, -100, 0],
-            x: [0, Math.random() * 100 - 50, 0],
-            opacity: [0.2, 0.8, 0.2],
-          }}
-          transition={{
-            duration: Math.random() * 10 + 10,
-            repeat: Infinity,
-            ease: "easeInOut",
-            delay: Math.random() * 5,
-          }}
-          style={{
-            top: `${Math.random() * 100}%`,
-            left: `${Math.random() * 100}%`,
-          }}
-        />
-      ))}
+      <canvas ref={canvasRef} className="absolute inset-0 pointer-events-none" />
 
       {/* Animated stars */}
       {[...Array(config.starCount)].map((_, i) => (
@@ -136,20 +138,21 @@ const AnimatedBackground = ({ variant = 'default' }) => {
           animate={{
             scale: [0, 1, 0],
             rotate: [0, 180, 360],
-            opacity: [0.3, 1, 0.3],
+            opacity: [0.3, 1, 0.3]
           }}
           transition={{
             duration: Math.random() * 3 + 2,
             repeat: Infinity,
-            ease: "easeInOut",
-            delay: Math.random() * 3,
+            ease: 'easeInOut',
+            delay: Math.random() * 3
           }}
           style={{
             top: `${Math.random() * 100}%`,
             left: `${Math.random() * 100}%`,
             width: `${Math.random() * 3 + 1}px`,
             height: `${Math.random() * 3 + 1}px`,
-            clipPath: 'polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)',
+            clipPath:
+              'polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)'
           }}
         />
       ))}
@@ -161,17 +164,17 @@ const AnimatedBackground = ({ variant = 'default' }) => {
           className={`absolute w-0.5 h-0.5 ${config.starColor} rounded-full`}
           animate={{
             opacity: [0, 1, 0],
-            scale: [0.5, 1.5, 0.5],
+            scale: [0.5, 1.5, 0.5]
           }}
           transition={{
             duration: Math.random() * 2 + 1,
             repeat: Infinity,
-            ease: "easeInOut",
-            delay: Math.random() * 2,
+            ease: 'easeInOut',
+            delay: Math.random() * 2
           }}
           style={{
             top: `${Math.random() * 100}%`,
-            left: `${Math.random() * 100}%`,
+            left: `${Math.random() * 100}%`
           }}
         />
       ))}


### PR DESCRIPTION
## Summary
- Replace DOM particle divs with a single `<canvas>` for drawing moving dots
- Show just one, smaller blurred orb to lighten the background effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint src/components/ui/animated-background.jsx`


------
https://chatgpt.com/codex/tasks/task_e_6899524c7f28833086044cae45df6f66